### PR TITLE
Upgraded component to Adafruit-circuitpython-mcp230xx version 2.0.1

### DIFF
--- a/custom_components/mcp23017/__init__.py
+++ b/custom_components/mcp23017/__init__.py
@@ -8,12 +8,12 @@ DOMAIN = 'mcp23017'
 
 def get_mcp(i2c_address):
     """Returns an MCP23017 chip object."""
-    import adafruit_mcp230xx
+    from adafruit_mcp230xx.mcp23017 import MCP23017
     import board
     import busio
 
     i2c = busio.I2C(board.SCL, board.SDA)
-    mcp = adafruit_mcp230xx.MCP23017(i2c, address=i2c_address)
+    mcp = MCP23017(i2c, address=i2c_address)
     return mcp
 
 def get_pin(mcp, pin_number):

--- a/custom_components/mcp23017/binary_sensor.py
+++ b/custom_components/mcp23017/binary_sensor.py
@@ -62,23 +62,16 @@ async def async_setup_platform(hass, config, async_add_devices,
     async_add_devices(binary_sensors, True)
 
     def int_config(pins):
-        gpintena = 0
-        gpintenb = 0
+        """Returns a 16 bit number with the bit set for each pin."""
+        gpinten = 0
         for pin in pins:
-            if pin < 8:
-                gpintena |= 1 << pin
-            else:
-                gpintenb |= 1 << pin - 8
-        return gpintena, gpintenb
+            gpinten |= 1 << pin
+        return gpinten
 
-    GPINTENA, GPINTENB = int_config(pins)
-    mcp._write_u8(0x04, GPINTENA) #Enable int on port A
-    mcp._write_u8(0x05, GPINTENB) #Enable int on port B
-    #mcp._write_u8(0x08, 0x00) #Interrupt on any change
-    #mcp._write_u8(0x09, 0x00) #Interrupt on any change
-    mcp._write_u8(0x0A, 0x44) #Set interrupt as open drain and mirrored
-    mcp._write_u8(0x0B, 0x44)
-    mcp._read_u8(0x10)
+    mcp.interrupt_enable = int_config(pins)
+    mcp.interrupt_configuration = 0x0000 # Interrupt on any change
+    mcp.io_control = 0x44 # Set interrupt as open drain and mirrored
+    mcp._read_u8(0x10) # Clear interrupts
     mcp._read_u8(0x11)
 
     def update_sensors(port):

--- a/custom_components/mcp23017/manifest.json
+++ b/custom_components/mcp23017/manifest.json
@@ -5,7 +5,7 @@
   "requirements": [
     "RPi.GPIO==0.6.5",
     "adafruit-blinka==1.2.1",
-    "adafruit-circuitpython-mcp230xx==1.1.2"
+    "adafruit-circuitpython-mcp230xx==2.0.1"
     ],
   "dependencies": [],
   "codeowners": ["@jardiamj"]


### PR DESCRIPTION
Upgraded mcp23017 component to Adafruit-circuitpython-mcp230xx version 2.0.1 with partial support for hardware interrupts.